### PR TITLE
Fix/swagger auth bearer

### DIFF
--- a/src/catalog/catalog.controller.ts
+++ b/src/catalog/catalog.controller.ts
@@ -10,23 +10,27 @@ import {
 import { CatalogService } from './catalog.service';
 import { UpdateCatalogDto } from './dto/update-catalog.dto';
 import { AddServiceDto } from './dto/add-service.dto';
+import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('catalog')
 export class CatalogController {
   constructor(private readonly catalogService: CatalogService) {}
 
   // Por ahora en controller por motivos de prueba, pero no debe existir como endpoint
+  @ApiBearerAuth()
   @Post('add/:providerId')
   async addCatalog(@Param('providerId') providerId: string) {
     return await this.catalogService.create(providerId);
   }
   // -----------------------------------------------------------------------------
 
+  @ApiBearerAuth()
   @Get(':providerId')
   async findOneByProviderId(@Param('providerId') providerId: string) {
     return await this.catalogService.findCatalogByProviderId(providerId);
   }
 
+  @ApiBearerAuth()
   @Patch(':providerId/description')
   async updateDescription(
     @Param('providerId') providerId: string,
@@ -35,6 +39,7 @@ export class CatalogController {
     return await this.catalogService.updateDescription(providerId, dto);
   }
 
+  @ApiBearerAuth()
   @Post(':providerId/services')
   async addService(
     @Param('providerId') providerId: string,
@@ -43,6 +48,7 @@ export class CatalogController {
     return await this.catalogService.addService(providerId, dto);
   }
 
+  @ApiBearerAuth()
   @Delete(':providerId/services/:serviceName')
   async removeService(
     @Param('providerId') providerId: string,
@@ -51,6 +57,7 @@ export class CatalogController {
     return await this.catalogService.removeService(providerId, serviceName);
   }
 
+  @ApiBearerAuth()
   @Patch(':providerId/services/:serviceName')
   async updateService(
     @Param('providerId') providerId: string,

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -8,6 +8,7 @@ import {
   ApiResponse,
   ApiParam,
   ApiBody,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { Event } from './event.document';
 import { Roles } from 'src/auth/roles.decorator';
@@ -18,6 +19,7 @@ import { Role } from 'src/auth/roles.enum';
 export class EventController {
   constructor(private readonly eventService: EventService) {}
 
+  @ApiBearerAuth()
   @Post()
   @Roles(Role.Organizer)
   @ApiOperation({ summary: 'Crear un nuevo evento' })
@@ -31,6 +33,7 @@ export class EventController {
     return await this.eventService.create(createEventDto);
   }
 
+  @ApiBearerAuth()
   @Get()
   @Roles(Role.Organizer)
   @ApiOperation({ summary: 'Listar todos los eventos' })
@@ -39,6 +42,7 @@ export class EventController {
     return await this.eventService.findAll();
   }
 
+  @ApiBearerAuth()
   @Put(':eventId')
   @Roles(Role.Organizer)
   @ApiOperation({ summary: 'Modificar un evento' })
@@ -52,6 +56,7 @@ export class EventController {
     return await this.eventService.update(id, updateEventDto);
   }
 
+  @ApiBearerAuth()
   @Patch(':eventId/finalize')
   @Roles(Role.Organizer)
   @ApiOperation({ summary: 'Finalizar un evento' })

--- a/src/quote/quote.controller.ts
+++ b/src/quote/quote.controller.ts
@@ -6,11 +6,16 @@
 // import { QuoteService } from './quote.service';
 // import { FilterSentQuotesDto } from './dto/filter-sent-quotes.dto';
 
+import { Controller } from '@nestjs/common';
+
 // interface RequestWithUser extends Request {
 //   user: { userId: number; role: Role; email: string };
 // }
 
-export class QuoteController {}
+@Controller()
+export class QuoteController {
+  constructor() {}
+}
 // @Controller('quote')
 // @UseGuards(JwtAuthGuard, RolesGuard)
 // export class QuoteController {


### PR DESCRIPTION
- descripción: Un pequeño cambio para que el proceso de uso de swagger no sea doloroso, con el use de la atenticación a través del auth bearer y su obtención de los headers automáticos
- Observaciones: Cuando vayan a crear un endpoint que necesite el auth bearer, pónganle @ApiBearerAuth() así cuando le den el token al candado, este se lo pasará al endpoint por los headers